### PR TITLE
Update osxfuse install to use cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pip install --user bridgy --ignore-installed six
 brew install tmux
 
 # optionally support remote mounts
-brew install osxfuse
+brew cask install osxfuse
 brew install sshfs
 ```
 


### PR DESCRIPTION
Looks like osxfuse is move to cask.
```
$brew install osxfuse
<snip> 
Error: No available formula with the name "osxfuse"
It was migrated from homebrew/core to caskroom/cask.
You can access it again by running:
  brew tap caskroom/cask

$brew cask install osxfuse
==> Caveats
To install and/or use osxfuse you may need to enable their kernel extension in

  System Preferences → Security & Privacy → General

For more information refer to vendor documentation or the Apple Technical Note:

  https://developer.apple.com/library/content/technotes/tn2459/_index.html

You must reboot for the installation of osxfuse to take effect.

==> Satisfying dependencies
==> Downloading https://github.com/osxfuse/osxfuse/releases/download/osxfuse-3.7.1/osxfuse-3.7.1.dmg
######################################################################## 100.0%
==> Verifying checksum for Cask osxfuse
==> Installing Cask osxfuse
==> Running installer for osxfuse; your password may be necessary.
==> Package installers may write to any location; options such as --appdir are ignored.
Password:
==> installer: Package name is FUSE for macOS
==> installer: choices changes file '/var/folders/qv/pkjbhp1x5rvbwn8psvgdwjxrzft_5f/T/choices20180116-9213-10jvxrj.xml' applied
==> installer: Installing at base path /
==> installer: The install was successful.
🍺  osxfuse was successfully installed!
```