### PR TITLE
Make shutdown instances be ignored

### DIFF
--- a/bridgy/inventory/aws.py
+++ b/bridgy/inventory/aws.py
@@ -55,9 +55,9 @@ class AwsInventory(InventorySource):
 
                 # try to find the best dns/ip address to reach this box
                 address = None
-                if instance['PublicDnsName']:
+                if instance.get('PublicDnsName'):
                     address = instance['PublicDnsName']
-                elif instance['PrivateIpAddress']:
+                elif instance.get('PrivateIpAddress'):
                     address = instance['PrivateIpAddress']
 
                 # try to find the best field to match a name against


### PR DESCRIPTION
Instances that are returned from boto may sometimes be shutdown,
or may not have an accesible IP. This causes those instances to
be filtered out from inventory.