### PR TITLE
Add ECS backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ bootstrap2: venv2
 	make clean
 
 venv2:
-	virtualenv -p python2 venv2
+	virtualenv -p python venv2
 	venv2/bin/pip install --upgrade pip
 	venv2/bin/pip install --upgrade setuptools
 

--- a/bridgy/inventory/aws.py
+++ b/bridgy/inventory/aws.py
@@ -3,10 +3,19 @@ import boto3
 import shutil
 import placebo
 import logging
+import itertools
 
 from bridgy.inventory.source import InventorySource, Instance, InstanceType
 
 logger = logging.getLogger()
+
+def groupsOf(n, iterable):
+    it = iter(iterable)
+    while True:
+       chunk = tuple(itertools.islice(it, n))
+       if not chunk:
+           return
+       yield chunk
 
 class AwsInventory(InventorySource):
 
@@ -40,15 +49,23 @@ class AwsInventory(InventorySource):
 
         self.pill = placebo.attach(session, data_path=cache_dir)
 
-        self.client = session.client('ec2')
+        self.ec2Client = session.client('ec2')
+        self.ecsClient = session.client('ecs')
 
     def update(self):
         try:
+            self.__ecs_search(stub=False)
             self.__ec2_search(stub=False)
         except KeyboardInterrupt:
             logger.error("Cancelled by user")
 
     def instances(self):
+        instances = []
+        # instances.extend(self.ec2Instances())
+        instances.extend(self.ecsInstances())
+        return instances
+
+    def ec2Instances(self):
         data = self.__ec2_search(stub=True)
 
         instances = []
@@ -90,6 +107,45 @@ class AwsInventory(InventorySource):
 
         return instances
 
+    def ecsInstances(self):
+        data = self.__ecs_search(stub=True)
+
+        print(data)
+
+        return []
+
+    def __ecs_search(self, value=None, stub=True):
+
+        def fetchData():
+            allTasks = []
+            taskDescriptions = {}
+            clusters = self.ecsClient.list_clusters()
+            for cluster in clusters['clusterArns']:
+                tasks = self.ecsClient.list_tasks(cluster=cluster)
+                allTasks.extend(tasks['taskArns'])
+                for taskArns in groupsOf(100, allTasks):
+                    descriptions = self.ecsClient.describe_tasks(cluster=cluster, tasks=taskArns)
+                    for taskDescription in descriptions['tasks']:
+                        taskDescriptions[taskDescription['taskArn']] = taskDescription
+
+            for x in taskDescriptions.items():
+                print(x)
+            return allTasks
+
+        if stub:
+            self.pill.playback()
+            allTasks = fetchData()
+        else:
+            # clear cache before updating
+            shutil.rmtree(self.cache_dir)
+            os.makedirs(self.cache_dir, mode=0o755)
+
+            # update
+            self.pill.record()
+            allTasks = fetchData()
+            self.pill.stop()
+        return allTasks
+
     def __ec2_search(self, tag=None, value=None, stub=True):
         filters = []
         if value:
@@ -100,7 +156,7 @@ class AwsInventory(InventorySource):
 
         if stub:
             self.pill.playback()
-            data = self.client.describe_instances(Filters=filters)
+            data = self.ec2Client.describe_instances(Filters=filters)
         else:
             # clear cache before updating
             shutil.rmtree(self.cache_dir)
@@ -108,6 +164,6 @@ class AwsInventory(InventorySource):
 
             # update
             self.pill.record()
-            data = self.client.describe_instances(Filters=filters)
+            data = self.ec2Client.describe_instances(Filters=filters)
             self.pill.stop()
         return data

--- a/bridgy/inventory/flatfile.py
+++ b/bridgy/inventory/flatfile.py
@@ -29,7 +29,7 @@ class CsvInventory(InventorySource):
             with open(self.csv_path, 'r') as csv_file:
                 reader = csv.DictReader(csv_file, fieldnames=self.fields, delimiter=self.delimiter)
                 for row in reader:
-                    instances.add(Instance(row['name'].strip(), row['address'].strip(), None, self.name, None, InstanceType.VM))
+                    instances.add(Instance(row['name'].strip(), row['address'].strip(), None, self.name, InstanceType.VM))
         except IOError as ex:
             logger.error("Unable to read inventory: %s" % ex)
             sys.exit(1)

--- a/bridgy/inventory/newrelic.py
+++ b/bridgy/inventory/newrelic.py
@@ -61,15 +61,15 @@ class NewRelicInventory(InventorySource):
                 address = event_dict['ipV4Address'].strip().split("/")[0]
                 if hostname is None:
                     hostname = address
-                instances.add(Instance(hostname, address, None, self.name, None, InstanceType.VM))
+                instances.add(Instance(hostname, address, None, self.name, InstanceType.VM))
 
         for results_dict in data[InstanceType.ECS]['results']:
             for event_dict in results_dict['events']:
                 container_name = event_dict['containerName']
-                container_id = event_dict['containerId']
+                # container_id = event_dict['containerId']
                 hostname = event_dict['hostname']
                 address = parseIpFromHostname(hostname)
 
-                instances.add(Instance(container_name, address, None, self.name, container_id, InstanceType.ECS))
+                instances.add(Instance(container_name, address, None, self.name, InstanceType.ECS))
 
         return list(instances)

--- a/bridgy/inventory/source.py
+++ b/bridgy/inventory/source.py
@@ -5,7 +5,7 @@ import collections
 from bridgy.error import MissingBastionHost
 
 with warnings.catch_warnings():
-    # Thiw warns about using the slow implementation of SequenceMatcher
+    # This warns about using the slow implementation of SequenceMatcher
     # instead of the python-Levenshtein module, which requires compilation.
     # I'd prefer for users tp simply use this tool without the need to
     # compile since the search space is probably fairly small

--- a/bridgy/inventory/source.py
+++ b/bridgy/inventory/source.py
@@ -18,7 +18,7 @@ class InstanceType:
     ECS = 'ECS'
 
 Bastion = collections.namedtuple("Bastion", "destination options")
-Instance = collections.namedtuple("Instance", "name address aliases source container_id type")
+Instance = collections.namedtuple("Instance", "name address aliases source type instanceId taskArn")
 # allow there to be optional kwargs that default to None
 Instance.__new__.__defaults__ = (None,) * len(Instance._fields)
 

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -16,14 +16,14 @@ def test_aws_instances(mocker):
                            region='region')
     instances = aws_obj.instances()
 
-    expected_instances = [Instance(name='test-forms', address='devbox', aliases=('devbox', 'ip-172-31-8-185.us-west-2.compute.internal', 'i-e54cbaeb'), source='aws', container_id=None, type='VM'),
-                          Instance(name='devlab-forms', address='devbox', aliases=('devbox', 'ip-172-31-0-138.us-west-2.compute.internal', 'i-f7d726f9'), source='aws', container_id=None, type='VM'),
-                          Instance(name='test-account-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-139.us-west-2.compute.internal', 'i-f4d726fa'), source='aws', container_id=None, type='VM'),
-                          Instance(name='devlab-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-0-142.us-west-2.compute.internal', 'i-f5d726fb'), source='aws', container_id=None, type='VM'),
-                          Instance(name='devlab-game-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-140.us-west-2.compute.internal', 'i-f2d726fc'), source='aws', container_id=None, type='VM'),
-                          Instance(name='test-game-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-141.us-west-2.compute.internal', 'i-f3d726fd'), source='aws', container_id=None, type='VM'),
-                          Instance(name='test-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-2-38.us-west-2.compute.internal', 'i-0f500447384e95942'), source='aws', container_id=None, type='VM'),
-                          Instance(name='test-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-2-39.us-west-2.compute.internal', 'i-0f500447384e95943'), source='aws', container_id=None, type='VM')]
+    expected_instances = [Instance(name='test-forms', address='devbox', aliases=('devbox', 'ip-172-31-8-185.us-west-2.compute.internal', 'i-e54cbaeb'), source='aws', type='VM'),
+                          Instance(name='devlab-forms', address='devbox', aliases=('devbox', 'ip-172-31-0-138.us-west-2.compute.internal', 'i-f7d726f9'), source='aws', type='VM'),
+                          Instance(name='test-account-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-139.us-west-2.compute.internal', 'i-f4d726fa'), source='aws', type='VM'),
+                          Instance(name='devlab-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-0-142.us-west-2.compute.internal', 'i-f5d726fb'), source='aws', type='VM'),
+                          Instance(name='devlab-game-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-140.us-west-2.compute.internal', 'i-f2d726fc'), source='aws', type='VM'),
+                          Instance(name='test-game-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-141.us-west-2.compute.internal', 'i-f3d726fd'), source='aws', type='VM'),
+                          Instance(name='test-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-2-38.us-west-2.compute.internal', 'i-0f500447384e95942'), source='aws', type='VM'),
+                          Instance(name='test-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-2-39.us-west-2.compute.internal', 'i-0f500447384e95943'), source='aws', type='VM')]
 
     assert set(instances) == set(expected_instances)
 
@@ -35,14 +35,14 @@ def test_aws_instances_profile(mocker):
     aws_obj = AwsInventory(cache_dir=cache_dir, profile='somewhere', region='region', config_path=config_dir)
     instances = aws_obj.instances()
 
-    expected_instances = [Instance(name='test-forms', address='devbox', aliases=('devbox', 'ip-172-31-8-185.us-west-2.compute.internal', 'i-e54cbaeb'), source='aws', container_id=None, type='VM'),
-                          Instance(name='devlab-forms', address='devbox', aliases=('devbox', 'ip-172-31-0-138.us-west-2.compute.internal', 'i-f7d726f9'), source='aws', container_id=None, type='VM'),
-                          Instance(name='test-account-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-139.us-west-2.compute.internal', 'i-f4d726fa'), source='aws', container_id=None, type='VM'),
-                          Instance(name='devlab-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-0-142.us-west-2.compute.internal', 'i-f5d726fb'), source='aws', container_id=None, type='VM'),
-                          Instance(name='devlab-game-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-140.us-west-2.compute.internal', 'i-f2d726fc'), source='aws', container_id=None, type='VM'),
-                          Instance(name='test-game-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-141.us-west-2.compute.internal', 'i-f3d726fd'), source='aws', container_id=None, type='VM'),
-                          Instance(name='test-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-2-38.us-west-2.compute.internal', 'i-0f500447384e95942'), source='aws', container_id=None, type='VM'),
-                          Instance(name='test-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-2-39.us-west-2.compute.internal', 'i-0f500447384e95943'), source='aws', container_id=None, type='VM')]
+    expected_instances = [Instance(name='test-forms', address='devbox', aliases=('devbox', 'ip-172-31-8-185.us-west-2.compute.internal', 'i-e54cbaeb'), source='aws', type='VM'),
+                          Instance(name='devlab-forms', address='devbox', aliases=('devbox', 'ip-172-31-0-138.us-west-2.compute.internal', 'i-f7d726f9'), source='aws', type='VM'),
+                          Instance(name='test-account-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-139.us-west-2.compute.internal', 'i-f4d726fa'), source='aws', type='VM'),
+                          Instance(name='devlab-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-0-142.us-west-2.compute.internal', 'i-f5d726fb'), source='aws', type='VM'),
+                          Instance(name='devlab-game-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-140.us-west-2.compute.internal', 'i-f2d726fc'), source='aws', type='VM'),
+                          Instance(name='test-game-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-141.us-west-2.compute.internal', 'i-f3d726fd'), source='aws', type='VM'),
+                          Instance(name='test-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-2-38.us-west-2.compute.internal', 'i-0f500447384e95942'), source='aws', type='VM'),
+                          Instance(name='test-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-2-39.us-west-2.compute.internal', 'i-0f500447384e95943'), source='aws', type='VM')]
 
     assert set(instances) == set(expected_instances)
 

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -40,9 +40,9 @@ def test_csv_instances(mocker):
     csv_obj = CsvInventory('/tmp/dummy/path', ' name,address, random ', ' | ')
     instances = csv_obj.instances()
     print(instances)
-    expected_instances = [Instance(name='devenv-pubsrv', address='13.14.15.16', source='csv', container_id=None, type='VM'),
-                          Instance(name='testenv-pubsrv', address='1.2.3.4', source='csv', container_id=None, type='VM'),
-                          Instance(name='devenv-pubsrv', address='9.10.11.12', source='csv', container_id=None, type='VM'),
-                          Instance(name='testenv-pubsrv', address='5.6.7.8', source='csv', container_id=None, type='VM'),
-                          Instance(name='testenv-formsvc', address='17.18.19.20', source='csv', container_id=None, type='VM')]
+    expected_instances = [Instance(name='devenv-pubsrv', address='13.14.15.16', source='csv', type='VM'),
+                          Instance(name='testenv-pubsrv', address='1.2.3.4', source='csv', type='VM'),
+                          Instance(name='devenv-pubsrv', address='9.10.11.12', source='csv', type='VM'),
+                          Instance(name='testenv-pubsrv', address='5.6.7.8', source='csv', type='VM'),
+                          Instance(name='testenv-formsvc', address='17.18.19.20', source='csv', type='VM')]
     assert set(instances) == set(expected_instances)

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -42,11 +42,11 @@ def test_inclusion_filtering(mocker):
 
     all_instances = instances(config)
 
-    expected_instances = [Instance(name='test-forms', address='devbox', aliases=('devbox', 'ip-172-31-8-185.us-west-2.compute.internal', 'i-e54cbaeb'), source='aws', container_id=None, type='VM'),
-                          Instance(name='test-account-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-139.us-west-2.compute.internal', 'i-f4d726fa'), source='aws', container_id=None, type='VM'),
-                          Instance(name='test-game-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-141.us-west-2.compute.internal', 'i-f3d726fd'), source='aws', container_id=None, type='VM'),
-                          Instance(name='test-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-2-38.us-west-2.compute.internal', 'i-0f500447384e95942'), source='aws', container_id=None, type='VM'),
-                          Instance(name='test-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-2-39.us-west-2.compute.internal', 'i-0f500447384e95943'), source='aws', container_id=None, type='VM')]
+    expected_instances = [Instance(name='test-forms', address='devbox', aliases=('devbox', 'ip-172-31-8-185.us-west-2.compute.internal', 'i-e54cbaeb'), source='aws', type='VM'),
+                          Instance(name='test-account-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-139.us-west-2.compute.internal', 'i-f4d726fa'), source='aws', type='VM'),
+                          Instance(name='test-game-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-141.us-west-2.compute.internal', 'i-f3d726fd'), source='aws', type='VM'),
+                          Instance(name='test-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-2-38.us-west-2.compute.internal', 'i-0f500447384e95942'), source='aws', type='VM'),
+                          Instance(name='test-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-2-39.us-west-2.compute.internal', 'i-0f500447384e95943'), source='aws', type='VM')]
 
     assert set(all_instances) == set(expected_instances)
 
@@ -71,8 +71,8 @@ def test_exclusion_filtering(mocker):
 
     all_instances = instances(config)
 
-    expected_instances = [Instance(name='devlab-forms', address='devbox', aliases=('devbox', 'ip-172-31-0-138.us-west-2.compute.internal', 'i-f7d726f9'), source='aws', container_id=None, type='VM'),
-                          Instance(name='devlab-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-0-142.us-west-2.compute.internal', 'i-f5d726fb'), source='aws', container_id=None, type='VM'),
-                          Instance(name='devlab-game-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-140.us-west-2.compute.internal', 'i-f2d726fc'), source='aws', container_id=None, type='VM')]
+    expected_instances = [Instance(name='devlab-forms', address='devbox', aliases=('devbox', 'ip-172-31-0-138.us-west-2.compute.internal', 'i-f7d726f9'), source='aws', type='VM'),
+                          Instance(name='devlab-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-0-142.us-west-2.compute.internal', 'i-f5d726fb'), source='aws', type='VM'),
+                          Instance(name='devlab-game-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-140.us-west-2.compute.internal', 'i-f2d726fc'), source='aws', type='VM')]
 
     assert set(all_instances) == set(expected_instances)

--- a/tests/test_inventory_set.py
+++ b/tests/test_inventory_set.py
@@ -31,14 +31,14 @@ def test_inventory_set(mocker):
     all_instances = inventorySet.instances()
 
     aws_instances = [
-        Instance(name=u'test-forms', address=u'devbox', aliases=(u'devbox', u'ip-172-31-8-185.us-west-2.compute.internal', u'i-e54cbaeb'), source='aws (aws)', container_id=None, type='VM'), 
-        Instance(name=u'devlab-forms', address=u'devbox', aliases=(u'devbox', u'ip-172-31-0-138.us-west-2.compute.internal', u'i-f7d726f9'), source='aws (aws)', container_id=None, type='VM'), 
-        Instance(name=u'test-account-svc', address=u'devbox', aliases=(u'devbox', u'ip-172-31-0-139.us-west-2.compute.internal', u'i-f4d726fa'), source='aws (aws)', container_id=None, type='VM'), 
-        Instance(name=u'devlab-pubsrv', address=u'devbox', aliases=(u'devbox', u'ip-172-31-0-142.us-west-2.compute.internal', u'i-f5d726fb'), source='aws (aws)', container_id=None, type='VM'), 
-        Instance(name=u'devlab-game-svc', address=u'devbox', aliases=(u'devbox', u'ip-172-31-0-140.us-west-2.compute.internal', u'i-f2d726fc'), source='aws (aws)', container_id=None, type='VM'), 
-        Instance(name=u'test-game-svc', address=u'devbox', aliases=(u'devbox', u'ip-172-31-0-141.us-west-2.compute.internal', u'i-f3d726fd'), source='aws (aws)', container_id=None, type='VM'), 
-        Instance(name=u'test-pubsrv', address=u'devbox', aliases=(u'devbox', u'ip-172-31-2-38.us-west-2.compute.internal', u'i-0f500447384e95942'), source='aws (aws)', container_id=None, type='VM'), 
-        Instance(name=u'test-pubsrv', address=u'devbox', aliases=(u'devbox', u'ip-172-31-2-39.us-west-2.compute.internal', u'i-0f500447384e95943'), source='aws (aws)', container_id=None, type='VM')
+        Instance(name=u'test-forms', address=u'devbox', aliases=(u'devbox', u'ip-172-31-8-185.us-west-2.compute.internal', u'i-e54cbaeb'), source='aws (aws)', type='VM'), 
+        Instance(name=u'devlab-forms', address=u'devbox', aliases=(u'devbox', u'ip-172-31-0-138.us-west-2.compute.internal', u'i-f7d726f9'), source='aws (aws)', type='VM'), 
+        Instance(name=u'test-account-svc', address=u'devbox', aliases=(u'devbox', u'ip-172-31-0-139.us-west-2.compute.internal', u'i-f4d726fa'), source='aws (aws)', type='VM'), 
+        Instance(name=u'devlab-pubsrv', address=u'devbox', aliases=(u'devbox', u'ip-172-31-0-142.us-west-2.compute.internal', u'i-f5d726fb'), source='aws (aws)', type='VM'), 
+        Instance(name=u'devlab-game-svc', address=u'devbox', aliases=(u'devbox', u'ip-172-31-0-140.us-west-2.compute.internal', u'i-f2d726fc'), source='aws (aws)', type='VM'), 
+        Instance(name=u'test-game-svc', address=u'devbox', aliases=(u'devbox', u'ip-172-31-0-141.us-west-2.compute.internal', u'i-f3d726fd'), source='aws (aws)', type='VM'), 
+        Instance(name=u'test-pubsrv', address=u'devbox', aliases=(u'devbox', u'ip-172-31-2-38.us-west-2.compute.internal', u'i-0f500447384e95942'), source='aws (aws)', type='VM'), 
+        Instance(name=u'test-pubsrv', address=u'devbox', aliases=(u'devbox', u'ip-172-31-2-39.us-west-2.compute.internal', u'i-0f500447384e95943'), source='aws (aws)', type='VM')
     ]
     
     expected_instances = aws_instances + aws_instances
@@ -58,24 +58,24 @@ def test_inventory_set_filter_sources(mocker):
     all_instances = inventorySet.instances(filter_sources='awesome')
 
     # aws_instances = [
-    #     Instance(name='test-forms', address='devbox', aliases=('devbox', 'ip-172-31-8-185.us-west-2.compute.internal', 'i-e54cbaeb'), source='aws (aws)', container_id=None, type='VM'), 
-    #     Instance(name='devlab-forms', address='devbox', aliases=('devbox', 'ip-172-31-0-138.us-west-2.compute.internal', 'i-f7d726f9'), source='aws (aws)', container_id=None, type='VM'), 
-    #     Instance(name='test-account-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-139.us-west-2.compute.internal', 'i-f4d726fa'), source='aws (aws)', container_id=None, type='VM'), 
-    #     Instance(name='devlab-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-0-142.us-west-2.compute.internal', 'i-f5d726fb'), source='aws (aws)', container_id=None, type='VM'), 
-    #     Instance(name='devlab-game-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-140.us-west-2.compute.internal', 'i-f2d726fc'), source='aws (aws)', container_id=None, type='VM'), 
-    #     Instance(name='test-game-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-141.us-west-2.compute.internal', 'i-f3d726fd'), source='aws (aws)', container_id=None, type='VM'), 
-    #     Instance(name='test-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-2-38.us-west-2.compute.internal', 'i-0f500447384e95942'), source='aws (aws)', container_id=None, type='VM'), 
-    #     Instance(name='test-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-2-39.us-west-2.compute.internal', 'i-0f500447384e95943'), source='aws (aws)', container_id=None, type='VM')
+    #     Instance(name='test-forms', address='devbox', aliases=('devbox', 'ip-172-31-8-185.us-west-2.compute.internal', 'i-e54cbaeb'), source='aws (aws)', type='VM'), 
+    #     Instance(name='devlab-forms', address='devbox', aliases=('devbox', 'ip-172-31-0-138.us-west-2.compute.internal', 'i-f7d726f9'), source='aws (aws)', type='VM'), 
+    #     Instance(name='test-account-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-139.us-west-2.compute.internal', 'i-f4d726fa'), source='aws (aws)', type='VM'), 
+    #     Instance(name='devlab-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-0-142.us-west-2.compute.internal', 'i-f5d726fb'), source='aws (aws)', type='VM'), 
+    #     Instance(name='devlab-game-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-140.us-west-2.compute.internal', 'i-f2d726fc'), source='aws (aws)', type='VM'), 
+    #     Instance(name='test-game-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-141.us-west-2.compute.internal', 'i-f3d726fd'), source='aws (aws)', type='VM'), 
+    #     Instance(name='test-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-2-38.us-west-2.compute.internal', 'i-0f500447384e95942'), source='aws (aws)', type='VM'), 
+    #     Instance(name='test-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-2-39.us-west-2.compute.internal', 'i-0f500447384e95943'), source='aws (aws)', type='VM')
     # ]
     awesome_instances = [
-        Instance(name='test-forms', address='devbox', aliases=('devbox', 'ip-172-31-8-185.us-west-2.compute.internal', 'i-e54cbaeb'), source='awesome (aws)', container_id=None, type='VM'), 
-        Instance(name='devlab-forms', address='devbox', aliases=('devbox', 'ip-172-31-0-138.us-west-2.compute.internal', 'i-f7d726f9'), source='awesome (aws)', container_id=None, type='VM'), 
-        Instance(name='test-account-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-139.us-west-2.compute.internal', 'i-f4d726fa'), source='awesome (aws)', container_id=None, type='VM'), 
-        Instance(name='devlab-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-0-142.us-west-2.compute.internal', 'i-f5d726fb'), source='awesome (aws)', container_id=None, type='VM'), 
-        Instance(name='devlab-game-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-140.us-west-2.compute.internal', 'i-f2d726fc'), source='awesome (aws)', container_id=None, type='VM'), 
-        Instance(name='test-game-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-141.us-west-2.compute.internal', 'i-f3d726fd'), source='awesome (aws)', container_id=None, type='VM'), 
-        Instance(name='test-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-2-38.us-west-2.compute.internal', 'i-0f500447384e95942'), source='awesome (aws)', container_id=None, type='VM'), 
-        Instance(name='test-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-2-39.us-west-2.compute.internal', 'i-0f500447384e95943'), source='awesome (aws)', container_id=None, type='VM')
+        Instance(name='test-forms', address='devbox', aliases=('devbox', 'ip-172-31-8-185.us-west-2.compute.internal', 'i-e54cbaeb'), source='awesome (aws)', type='VM'), 
+        Instance(name='devlab-forms', address='devbox', aliases=('devbox', 'ip-172-31-0-138.us-west-2.compute.internal', 'i-f7d726f9'), source='awesome (aws)', type='VM'), 
+        Instance(name='test-account-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-139.us-west-2.compute.internal', 'i-f4d726fa'), source='awesome (aws)', type='VM'), 
+        Instance(name='devlab-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-0-142.us-west-2.compute.internal', 'i-f5d726fb'), source='awesome (aws)', type='VM'), 
+        Instance(name='devlab-game-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-140.us-west-2.compute.internal', 'i-f2d726fc'), source='awesome (aws)', type='VM'), 
+        Instance(name='test-game-svc', address='devbox', aliases=('devbox', 'ip-172-31-0-141.us-west-2.compute.internal', 'i-f3d726fd'), source='awesome (aws)', type='VM'), 
+        Instance(name='test-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-2-38.us-west-2.compute.internal', 'i-0f500447384e95942'), source='awesome (aws)', type='VM'), 
+        Instance(name='test-pubsrv', address='devbox', aliases=('devbox', 'ip-172-31-2-39.us-west-2.compute.internal', 'i-0f500447384e95943'), source='awesome (aws)', type='VM')
     ]
 
     assert len(all_instances) == len(awesome_instances)

--- a/tests/test_newrelic.py
+++ b/tests/test_newrelic.py
@@ -118,11 +118,11 @@ def test_newrelic_instances():
     newrelic_obj = NewRelicInventory('account_number','api_key','/tmp/dummy/path')
     instances = newrelic_obj.instances()
     expected_instances = [
-        Instance(name=u'coolcucumber', address=None, aliases=None, source='acct:account_number (newrelic)', container_id=u'cc3456789098765432', type='ECS'), 
-        Instance(name=u'ip-172-16-223-200', address=u'172.16.223.200', aliases=None, source='acct:account_number (newrelic)', container_id=None, type='VM'), 
-        Instance(name=u'i-0f9a3f0d9399a6c17-PROD-prfsvclmt', address=u'172.16.225.232', aliases=None, source='acct:account_number (newrelic)', container_id=None, type='VM'), 
-        Instance(name=u'awesomecontainer', address=u'672.16.223.200', aliases=None, source='acct:account_number (newrelic)', container_id=u'123456789098765432', type='ECS'), 
-        Instance(name=u'ardvark?', address=None, aliases=None, source='acct:account_number (newrelic)', container_id=u'dd3456789098765432', type='ECS'), 
-        Instance(name=u'i-04267e627f88362ed-DEV-self-formsvc', address=u'172.16.221.211', aliases=None, source='acct:account_number (newrelic)', container_id=None, type='VM')
+        Instance(name=u'coolcucumber', address=None, aliases=None, source='acct:account_number (newrelic)', type='ECS'), 
+        Instance(name=u'ip-172-16-223-200', address=u'172.16.223.200', aliases=None, source='acct:account_number (newrelic)', type='VM'), 
+        Instance(name=u'i-0f9a3f0d9399a6c17-PROD-prfsvclmt', address=u'172.16.225.232', aliases=None, source='acct:account_number (newrelic)', type='VM'), 
+        Instance(name=u'awesomecontainer', address=u'672.16.223.200', aliases=None, source='acct:account_number (newrelic)', type='ECS'), 
+        Instance(name=u'ardvark?', address=None, aliases=None, source='acct:account_number (newrelic)', type='ECS'), 
+        Instance(name=u'i-04267e627f88362ed-DEV-self-formsvc', address=u'172.16.221.211', aliases=None, source='acct:account_number (newrelic)', type='VM')
     ]
     assert set(instances) == set(expected_instances)


### PR DESCRIPTION
This is a start for #32 , what is missing currently is the exact curl command on the ECS instance to query the docker ID from the ECS agent (when given a task ID)... this is an open PR until that is solved. 