### PR TITLE
Add Codecov coverage reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # bridgy
 
 ![Image](https://api.travis-ci.org/wagoodman/bridgy.svg?branch=master)  [![PyPI version](https://badge.fury.io/py/bridgy.svg)](https://badge.fury.io/py/bridgy)
+[![codecov.io](https://codecov.io/github/wagoodman/bridgy/coverage.svg?branch=master)](https://codecov.io/github/wagoodman/bridgy)
 (***WIP/beta***)
 
 **TL;DR**: bridgy = ssh + tmux + sshfs + cloud inventory search

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,19 @@
 [tox]
-envlist = 	py2
-			py3
+envlist =   py2
+            py3
 
 [testenv]
-commands =	coverage erase
-						coverage run --source bridgy -m py.test
-						coverage report
+
+commands =  coverage erase
+            coverage run --source bridgy -m py.test
+            coverage report
+            codecov -e TOXENV
 deps=
-	-r{toxinidir}/requirements.txt
-	pytest
-	coverage
-	mock
-	pytest-mock
+      -r{toxinidir}/requirements.txt
+      pytest
+      coverage
+      codecov>=1.4.0
+      mock
+      pytest-mock
+passenv=
+      CI TRAVIS TRAVIS_*


### PR DESCRIPTION
Hey, Tom from Codecov here.  I am a big fan of bridgy, and I noticed that you were already displaying code coverage in the Travis build.

I thought it would be useful to add more useful code coverage metrics to this repository.  [Codecov](https://codecov.io) is a hosted code coverage provider with awesome features. You can checkout your first reports [here](https://codecov.io/gh/thomasrockhu/bridgy).

I would love all the feedback you have, and I look forward to having bridgy on Codecov :)

Cheers,
Tom

Codecov :heart: open source and will be free forever for OSS