### PR TITLE
fix(yamlloader): specified the loader explicitly

### DIFF
--- a/bridgy/config/__init__.py
+++ b/bridgy/config/__init__.py
@@ -16,7 +16,7 @@ def _readConfig():
                          Representer.represent_str)
     try:
         with open(os.path.expanduser(ConfigBase.path), 'r') as fh:
-            config = yaml.load(fh)
+            config = yaml.load(fh, Loader=yaml.SafeLoader)
     except Exception as ex:
         logger.error("Unable to read config (%s): %s" % (ConfigBase.path, ex))
         sys.exit(1)

--- a/bridgy/config/base.py
+++ b/bridgy/config/base.py
@@ -69,7 +69,7 @@ class ConfigBase(object):
                              Representer.represent_str)
         try:
             with open(os.path.expanduser(self.path), 'r') as fh:
-                self.conf = yaml.load(fh)
+                self.conf = yaml.load(fh, Loader=yaml.SafeLoader)
         except Exception as ex:
             logger.error("Unable to read config (%s): %s" % (self.path, ex))
             sys.exit(1)


### PR DESCRIPTION
Was confronted with the following messages:
```
.../bridgy/config/__init__.py:19: YAMLLoadWarning: calling yaml.load() 
without Loader=... is deprecated, as the default Loader is unsafe. 
Please read https://msg.pyyaml.org/load for full details.
  config = yaml.load(fh)
.../bridgy/config/base.py:72: YAMLLoadWarning: calling yaml.load() 
without Loader=... is deprecated, as the default Loader is unsafe. 
Please read https://msg.pyyaml.org/load for full details.
  self.conf = yaml.load(fh)
```
The linked webpage suggests an easy solution to this, so I implemented it. If the SafeLoader is not fitting because of some specialties unknown to me, please tell me - I will gladly change it to the `FullLoader` if there is a reason to do so.