### PR TITLE
Wrap ssh command to avoid tmux error

### DIFF
--- a/bridgy/command/ssh.py
+++ b/bridgy/command/ssh.py
@@ -44,7 +44,7 @@ class Ssh(object):
 
     @property
     def command(self):
-        cmd = 'ssh {options} {destination} {command}'
+        cmd = "'ssh {options} {destination} {command}'"
         return cmd.format(destination=self.destination,
                           options=self.options,
                           command=self.custom_command)

--- a/bridgy/config/__init__.py
+++ b/bridgy/config/__init__.py
@@ -16,7 +16,7 @@ def _readConfig():
                          Representer.represent_str)
     try:
         with open(os.path.expanduser(ConfigBase.path), 'r') as fh:
-            config = yaml.load(fh)
+            config = yaml.load(fh, Loader=yaml.FullLoader)
     except Exception as ex:
         logger.error("Unable to read config (%s): %s" % (ConfigBase.path, ex))
         sys.exit(1)

--- a/bridgy/config/base.py
+++ b/bridgy/config/base.py
@@ -69,7 +69,7 @@ class ConfigBase(object):
                              Representer.represent_str)
         try:
             with open(os.path.expanduser(self.path), 'r') as fh:
-                self.conf = yaml.load(fh)
+                self.conf = yaml.load(fh, Loader=yaml.FullLoader)
         except Exception as ex:
             logger.error("Unable to read config (%s): %s" % (self.path, ex))
             sys.exit(1)


### PR DESCRIPTION
I get an error while running tmux commands, whilst under aws-vault. Wrapping the ssh command in quotes solves this

```
❯ aws-vault exec nonprod-dev -- bridgy ssh -t "my-node"
Found credentials in shared credentials file: ~/.aws/credentials
Tmux failed (rc:1, error:'usage: new-session [-AdDP] [-F format] [-n window-name] [-s session-name] [-t target-session] [-x width] [-y height] [command]'): tmux new-session -ds tmux-10799 -n remote-session ssh   -t user@ip_address 
Tmux failed (rc:1, error:'failed to connect to server'): tmux select-layout -t tmux-10799 tiled
Tmux failed (rc:1, error:'no sessions'): tmux attach -t tmux-10799
```
